### PR TITLE
Add favorite_count and truncated in tweet payload to model

### DIFF
--- a/src/BoxKite.Twitter.Tests/DecodeTests.cs
+++ b/src/BoxKite.Twitter.Tests/DecodeTests.cs
@@ -161,6 +161,8 @@ namespace BoxKite.Twitter.Tests
             Assert.IsNull(tweet.Place);
             Assert.IsNull(tweet.RetweetedStatus);
             tweet.Favourited.ShouldBeEquivalentTo(false);
+            tweet.FavoriteCount.ShouldBeEquivalentTo(10);
+            tweet.Truncated.ShouldBeEquivalentTo(true);
             tweet.Source.ShouldBeEquivalentTo(
                 "<a href=\"http://jason-costa.blogspot.com\" rel=\"nofollow\">My Shiny App</a>");
             tweet.Text.ShouldBeEquivalentTo("Maybe he'll finally find his keys. #peterfalk");

--- a/src/BoxKite.Twitter.Tests/data/tweets/singletweet.txt
+++ b/src/BoxKite.Twitter.Tests/data/tweets/singletweet.txt
@@ -1,8 +1,9 @@
 ﻿{
   "coordinates": null,
   "favorited": false,
+  "favorite_count": 10,
   "created_at": "Wed Sep 05 00:37:15 +0000 2012",
-  "truncated": false,
+  "truncated": true,
   "id_str": "243145735212777472",
   "entities": {
     "urls": [

--- a/src/BoxKite.Twitter/Models/Tweet.cs
+++ b/src/BoxKite.Twitter/Models/Tweet.cs
@@ -128,6 +128,23 @@ namespace BoxKite.Twitter.Models
             get { return _retweetedStatus; }
             set { SetProperty(ref _retweetedStatus, value); }
         }
+
+        private int _favoriteCount;
+
+        [JsonProperty("favorite_count")]
+        public int FavoriteCount
+        {
+            get { return _favoriteCount; }
+            set { _favoriteCount = value; }
+        }
+
+        private bool _truncated;
+        [JsonProperty("truncated")]
+        public bool Truncated
+        {
+            get { return _truncated; }
+            set { _truncated = value; }
+        }
     }
 
     public class Entities


### PR DESCRIPTION
Hi 

This is change to tweet model to support favorite_count and truncated.
https://dev.twitter.com/docs/platform-objects/tweets

Would you please consider a minor release 1.5.1 to add this changes?

Cheers
