### PR TITLE
Added video info & extended entities

### DIFF
--- a/src/BoxKite.Twitter/Models/Tweet.cs
+++ b/src/BoxKite.Twitter/Models/Tweet.cs
@@ -79,6 +79,24 @@ namespace BoxKite.Twitter.Models
         public IEnumerable<Media> Media { get; set; }
     }
 
+    public class Variant
+    {
+        public int Bitrate { get; set; }
+        [JsonProperty("content_type")]
+        public string ContentType { get; set; }
+        public string Url { get; set; }
+    }
+
+    public class VideoInfo
+    {
+        [JsonProperty("aspect_ratio")]
+        public List<int> AspectRatio { get; set; }
+        [JsonProperty("duration_millis")]
+        public int Duration { get; set; }
+
+        public List<Variant> Variants { get; set; }
+    }
+
     public class Url
     {
         [JsonProperty("indices")]
@@ -146,6 +164,9 @@ namespace BoxKite.Twitter.Models
 
         [JsonProperty("media_url_https")]
         public string MediaUrlHttps { get; set; }
+
+        [JsonProperty("video_info")]
+        public VideoInfo VideoInfo { get; set; }
     }
 
     public class Sizes

--- a/src/BoxKite.Twitter/Models/Tweet.cs
+++ b/src/BoxKite.Twitter/Models/Tweet.cs
@@ -54,6 +54,9 @@ namespace BoxKite.Twitter.Models
         [JsonProperty("entities")]
          public Entities Entities { get; set; }
 
+        [JsonProperty("extended_entities")]
+        public Entities ExtendedEntities { get; set; }
+
         [JsonProperty("retweeted_status")]
         public Tweet RetweetedStatus { get; set; }
 


### PR DESCRIPTION
As outlined in the [twitter docs](https://twittercommunity.com/t/twitter-video-support-in-rest-and-streaming-api/31258), I've added the extra entities associated with todays announcement of video rendering.

[This is how "animated gifs" should attach too](https://twittercommunity.com/t/adding-animated-gifs-via-rest-and-streaming-apis/30070)

Unfortunately it hasn't been rolled out to the API yet?